### PR TITLE
feat(demarcot): move lsp diagnostic block to allow virtual text

### DIFF
--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -37,10 +37,6 @@ lsp.set_preferences({
     }
 })
 
-vim.diagnostic.config({
-    virtual_text = true,
-})
-
 lsp.on_attach(function(client, bufnr)
   local opts = {buffer = bufnr, remap = false}
 
@@ -63,4 +59,7 @@ end)
 
 lsp.setup()
 
+vim.diagnostic.config({
+    virtual_text = true,
+})
 


### PR DESCRIPTION
It seems the vim.diagnostic.config block only takes effect if it comes after the lsp.setup() call. With this change, the user should have virtual text visible.