### PR TITLE
Fix Transparency

### DIFF
--- a/after/plugin/colors.lua
+++ b/after/plugin/colors.lua
@@ -1,3 +1,6 @@
+require('rose-pine').setup({
+    disable_background = true
+})
 
 function ColorMyPencils(color) 
 	color = color or "rose-pine"


### PR DESCRIPTION
Hello, when using the current config and opening a split, telescope or any other window the transparency gets fckd up and this PR fixes it (when using rose-pine).