### PR TITLE
Remove duplicate definition of leader.

### DIFF
--- a/lua/theprimeagen/set.lua
+++ b/lua/theprimeagen/set.lua
@@ -30,7 +30,3 @@ vim.opt.updatetime = 50
 
 vim.opt.colorcolumn = "80"
 
-vim.g.mapleader = " "
-
-
-


### PR DESCRIPTION
Leader is being defined in the `set.lua` and `remap.lua`. Since `remap.lua` is where `<leader>` is being used, it seems more fitting to leave it there. Thus removed it from `set.lua`.