### PR TITLE
add ripgrep as a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ### ThePrimeagen's init.lua
+Prerequisite: install [ripgrep](https://github.com/BurntSushi/ripgrep).
+
 [The full video of me setting up this repo](https://www.youtube.com/watch?v=w7i4amO_zaE)
 
 For anyone that is interested in my vimrc, i will have a commit log below


### PR DESCRIPTION
Adds a note on the issue when `<leader>ps` doesn't work without [ripgrep](https://github.com/BurntSushi/ripgrep) – #13.