### PR TITLE
fix undefind vim in lua lsp

### DIFF
--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -9,15 +9,7 @@ lsp.ensure_installed({
 })
 
 -- Fix Undefined global 'vim'
-lsp.configure('sumneko_lua', {
-    settings = {
-        Lua = {
-            diagnostics = {
-                globals = { 'vim' }
-            }
-        }
-    }
-})
+lsp.nvim_workspace()
 
 
 local cmp = require('cmp')


### PR DESCRIPTION
Reverts #5 and use `nvim_workspace`.

Source: [https://github.com/VonHeikemen/lsp-zero.nvim/blob/main/advance-usage.md](https://github.com/VonHeikemen/lsp-zero.nvim/blob/main/advance-usage.md)