### PR TITLE
Changed the configuration for sumneko_lua to the recommended configuration by nvim-lspconfig

### DIFF
--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -8,12 +8,26 @@ lsp.ensure_installed({
   'rust_analyzer',
 })
 
--- Fix Undefined global 'vim'
+-- Set up sumneko_lua according to the
+-- recommended settings by nvim-lspconfig
 lsp.configure('sumneko_lua', {
     settings = {
         Lua = {
+            runtime = {
+                -- Tell the language server which version of Lua you're using (most likely LuaJIT in the case of Neovim)
+                version = "LuaJIT"
+            },
             diagnostics = {
+                -- Get the langauge server to recognize the `vim` global
                 globals = { 'vim' }
+            },
+            workspace = {
+                -- Make the server aware of Neovim runtime files
+                library = vim.api.nvim_get_runtime_file("", true)
+            },
+            -- Do not send telemetry data containing a randomized but unique identifier
+            telemetry = {
+                enable = false
             }
         }
     }


### PR DESCRIPTION
My rationale for this is that most Neovim users (I believe it is the case for you as well) would only use the Lua language server for Neovim configuration and plugin development instead of doing regular programming and development using Lua. The recommended settings by nvim-lspconfig can be found [here.](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#sumneko_lua)

However, these settings will significantly increase the time it takes for the language server to handle initial requests upon starting as well as the time to first diagnostics. Completion results will also include a workspace indexing progress message until the language server has finished indexing. This disclaimer is also written on the [nvim-lspconfig page](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#sumneko_lua).

An alternative to setting up the language server this way would be to install the [`folke/neodev.nvim`](https://github.com/folke/neodev.nvim) plugin to facilitate configuration and plugin development on Neovim. However, in my experience, it makes the language server much slower. The autocompletion suggestions and diagnostics have a noticeable delay, sometimes up to a few seconds, instead of being instant. And this is the case on every autocompletion suggestion and diagnostic message, which would be irritating to deal with. But the upside is that the language server can service initial requests instantly and doesn’t need to take time to initialise and index the workspace.

Feel free to reject this pull request if the trade-offs aren’t worth it for you.