### PR TITLE
feat: change deprecated name sumneko_lua to lua_ls

### DIFF
--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -4,12 +4,12 @@ lsp.preset("recommended")
 
 lsp.ensure_installed({
   'tsserver',
-  'sumneko_lua',
+  'lua_ls',
   'rust_analyzer',
 })
 
 -- Fix Undefined global 'vim'
-lsp.configure('sumneko_lua', {
+lsp.configure('lua_ls', {
     settings = {
         Lua = {
             diagnostics = {


### PR DESCRIPTION
As pointed out on [#2439](https://github.com/neovim/nvim-lspconfig/pull/2439) sumneko_lua is now called lua_ls. The proposed modification prevents a "deprecated" warning regarding the old name.