### PR TITLE
Modify defaults to use pwsh on Windows

### DIFF
--- a/lua/theprimeagen/set.lua
+++ b/lua/theprimeagen/set.lua
@@ -30,3 +30,14 @@ vim.opt.updatetime = 50
 
 vim.opt.colorcolumn = "80"
 
+if vim.loop.os_uname().sysname == 'Windows_NT' then
+    vim.o.shell = 'pwsh'
+    vim.o.shellcmdflag =
+    [[-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command
+    [Console]::InputEncoding=[Console]::OutputEncoding =
+    [System.Text.Encoding]::UTF8;]]
+    vim.o.shellredir = '2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode'
+    vim.o.shellpipe = '2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode'
+    vim.o.shellquote = ''
+    vim.o.shellxquote = ''
+end

--- a/lua/theprimeagen/set.lua
+++ b/lua/theprimeagen/set.lua
@@ -31,13 +31,20 @@ vim.opt.updatetime = 50
 vim.opt.colorcolumn = "80"
 
 if vim.loop.os_uname().sysname == 'Windows_NT' then
-    vim.o.shell = 'pwsh'
-    vim.o.shellcmdflag =
+
+    -- Use Powershell Core, if not available Windows Powershell
+    if vim.fn.executable('pwsh') == 1 then
+        vim.opt.shell = 'pwsh'
+    else
+        vim.opt.shell = 'powershell'
+    end
+
+    vim.opt.shellcmdflag =
     [[-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command
     [Console]::InputEncoding=[Console]::OutputEncoding =
     [System.Text.Encoding]::UTF8;]]
-    vim.o.shellredir = '2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode'
-    vim.o.shellpipe = '2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode'
-    vim.o.shellquote = ''
-    vim.o.shellxquote = ''
+    vim.opt.shellredir = '2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode'
+    vim.opt.shellpipe = '2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode'
+    vim.opt.shellquote = ''
+    vim.opt.shellxquote = ''
 end


### PR DESCRIPTION
This makes Neovim use Powershell Core when on Windows for `:!` and `:term` commands. It's kind of opinionated but I believe it's better than defaulting to the old cmd.