### PR TITLE
Dont loose bg waifu when PackerSync

### DIFF
--- a/lua/theprimeagen/packer.lua
+++ b/lua/theprimeagen/packer.lua
@@ -16,9 +16,6 @@ return require('packer').startup(function(use)
   use({
 	  'rose-pine/neovim',
 	  as = 'rose-pine',
-	  config = function()
-		  vim.cmd('colorscheme rose-pine')
-	  end
   })
 
   use({


### PR DESCRIPTION
I'm kinda new to NeoVim, but from what I understood, what was causing us to loose our _waifu_ background when doing `:PackerSync` is because `rose-pine` changes the `colorscheme` when initialized, which is fine, but we have our own custom `ColorMyPencils` which already does that and preserves our _waifu_ background.