### PR TITLE
Feature/commentary toggleterm split screen

### DIFF
--- a/after/plugin/toggleterm.lua
+++ b/after/plugin/toggleterm.lua
@@ -1,0 +1,31 @@
+require("toggleterm").setup{
+  size = function(term)
+    if term.direction == "float" then
+      return 20
+    elseif term.direction == "horizontal" then
+      return 15
+    elseif term.direction == "vertical" then
+      return vim.o.columns * 0.4
+    end
+  end,
+  open_mapping = [[<c-\>]],
+  hide_numbers = true,
+  shade_filetypes = {},
+  shade_terminals = true,
+  shading_factor = 2,
+  start_in_insert = true,
+  insert_mappings = true,
+  persist_size = true,
+  direction = "float",
+  close_on_exit = true,
+  shell = vim.o.shell,
+  float_opts = {
+    border = "curved",
+    winblend = 0,
+    highlights = {
+      border = "Normal",
+      background = "Normal",
+    },
+  },
+}
+

--- a/lua/theprimeagen/packer.lua
+++ b/lua/theprimeagen/packer.lua
@@ -40,7 +40,9 @@ return require('packer').startup(function(use)
   use("theprimeagen/refactoring.nvim")
   use("mbbill/undotree")
   use("tpope/vim-fugitive")
+  use("tpope/vim-commentary")
   use("nvim-treesitter/nvim-treesitter-context");
+  use("akinsho/toggleterm.nvim")
 
   use {
 	  'VonHeikemen/lsp-zero.nvim',

--- a/lua/theprimeagen/remap.lua
+++ b/lua/theprimeagen/remap.lua
@@ -1,4 +1,6 @@
 
+local opts = { noremap = true, silent = true }
+
 vim.g.mapleader = " "
 vim.keymap.set("n", "<leader>pv", vim.cmd.Ex)
 
@@ -10,6 +12,21 @@ vim.keymap.set("n", "<C-d>", "<C-d>zz")
 vim.keymap.set("n", "<C-u>", "<C-u>zz")
 vim.keymap.set("n", "n", "nzzzv")
 vim.keymap.set("n", "N", "Nzzzv")
+
+-- Resize with arrows
+vim.keymap.set("n", "<C-Up>", ":resize -2<CR>", opts)
+vim.keymap.set("n", "<C-Down>", ":resize +2<CR>", opts)
+vim.keymap.set("n", "<C-Left>", ":vertical resize -2<CR>", opts)
+vim.keymap.set("n", "<C-Right>", ":vertical resize +2<CR>", opts)
+
+-- Move text up and down
+vim.keymap.set("v", "<A-j>", ":m .+1<CR>==", opts)
+vim.keymap.set("v", "<A-k>", ":m .-2<CR>==", opts)
+
+-- Visual Block --
+-- Move text up and down
+vim.keymap.set("x", "<A-j>", ":move '>+1<CR>gv-gv", opts)
+vim.keymap.set("x", "<A-k>", ":move '<-2<CR>gv-gv", opts)
 
 vim.keymap.set("n", "<leader>vwm", function()
     require("vim-with-me").StartVimWithMe()


### PR DESCRIPTION
Dear ThePrimeagen,

I am writing to submit a pull request with several changes I made to your init.lua repository. The changes are intended to improve the usability of the editor by adding some useful key mappings, a commenting plugin, and a terminal toggle.

The changes include:

- Added mappings for resizing the split screen and moving text up and down in visual and visual block mode
- Added the "tpope/vim-commentary" plugin for commenting
- Added the "akinsho/toggleterm.nvim" plugin for toggling the terminal
- Created a "toggleterm.lua" file with configuration settings for the terminal plugin

I have created a new branch called "Feature/commentary toggleterm split screen" for these changes. Please let me know if there are any issues with the changes, or if you have any suggestions for improvements.

Thank you for your time and consideration.

Best regards,
zbluee
