### PR TITLE
fix: help renamed to vimdoc

### DIFF
--- a/after/plugin/treesitter.lua
+++ b/after/plugin/treesitter.lua
@@ -1,6 +1,6 @@
 require'nvim-treesitter.configs'.setup {
   -- A list of parser names, or "all"
-  ensure_installed = { "help", "javascript", "typescript", "c", "lua", "rust" },
+  ensure_installed = { "vimdoc", "javascript", "typescript", "c", "lua", "rust" },
 
   -- Install parsers synchronously (only applied to `ensure_installed`)
   sync_install = false,


### PR DESCRIPTION
https://github.com/nvim-treesitter/nvim-treesitter/pull/4593

nvim-treesitter has a breaking change here.