### PR TITLE
fix: require for packer.lua

### DIFF
--- a/lua/theprimeagen/init.lua
+++ b/lua/theprimeagen/init.lua
@@ -1,5 +1,6 @@
 require("theprimeagen.set")
 require("theprimeagen.remap")
+require("theprimeagen.packer")
 
 -- DO NOT INCLUDE THIS
 vim.opt.rtp:append("~/personal/streamer-tools")


### PR DESCRIPTION
I believe this allows packer to be started when starting the program. In my case it previously required me to source manually the packer.lua to use the :Packer commands. Please correct me if I'm wrong, but this could be an interesting fix for autoloading the packer.lua file