### PR TITLE
quickfix: fixed fugitive pull/rebase command.

### DIFF
--- a/after/plugin/fugitive.lua
+++ b/after/plugin/fugitive.lua
@@ -19,7 +19,7 @@ autocmd("BufWinEnter", {
 
         -- rebase always
         vim.keymap.set("n", "<leader>P", function()
-            vim.cmd.Git({'pull',  '--rebase'})
+            vim.cmd.Git({'pull --rebase'})
         end, opts)
 
         -- NOTE: It allows me to easily set the branch i am pushing and any tracking


### PR DESCRIPTION
Invoking "<leader>P" caused the following error:

```
E5108: Error executing lua: ...jon/dotfiles/nvim/.config/nvim/after/plugin/fugitive.lua:26: Wro ng number of arguments
stack traceback:
        [C]: in function 'Git'
        ...jon/dotfiles/nvim/.config/nvim/after/plugin/fugitive.lua:26: in function <...jon/dot
files/nvim/.config/nvim/after/plugin/fugitive.lua:25>
```

Using a single string seems to have fixed the issue.