### PR TITLE
Disable continuation of comments to the next line

### DIFF
--- a/lua/theprimeagen/set.lua
+++ b/lua/theprimeagen/set.lua
@@ -30,3 +30,4 @@ vim.opt.updatetime = 50
 
 vim.opt.colorcolumn = "80"
 
+vim.cmd([[autocmd BufEnter * set formatoptions-=o]])


### PR DESCRIPTION
vim.opt.formatoptions:remove("o")  doesn't work, seems to be overrided by other plugin.  