### PR TITLE
chore: vim.lsp.buf.hover() key map

### DIFF
--- a/lua/theprimeagen/init.lua
+++ b/lua/theprimeagen/init.lua
@@ -51,7 +51,6 @@ autocmd('LspAttach', {
     callback = function(e)
         local opts = { buffer = e.buf }
         vim.keymap.set("n", "gd", function() vim.lsp.buf.definition() end, opts)
-        vim.keymap.set("n", "K", function() vim.lsp.buf.hover() end, opts)
         vim.keymap.set("n", "<leader>vws", function() vim.lsp.buf.workspace_symbol() end, opts)
         vim.keymap.set("n", "<leader>vd", function() vim.diagnostic.open_float() end, opts)
         vim.keymap.set("n", "<leader>vca", function() vim.lsp.buf.code_action() end, opts)


### PR DESCRIPTION
Remove vim.lsp.buf.hover() key map as it’s built-in since Neovim v0.10.