### PR TITLE
chore: LspRestart key map

### DIFF
--- a/lua/theprimeagen/remap.lua
+++ b/lua/theprimeagen/remap.lua
@@ -10,7 +10,7 @@ vim.keymap.set("n", "<C-d>", "<C-d>zz")
 vim.keymap.set("n", "<C-u>", "<C-u>zz")
 vim.keymap.set("n", "n", "nzzzv")
 vim.keymap.set("n", "N", "Nzzzv")
-vim.keymap.set("n", "<leader>zig", "<cmd>LspRestart<cr>")
+vim.keymap.set("n", "<leader>zig", vim.cmd.LspRestart)
 
 vim.keymap.set("n", "<leader>vwm", function()
     require("vim-with-me").StartVimWithMe()


### PR DESCRIPTION
Replace the right-hand side of the LspRestart key map with a function.