### PR TITLE
neotest requires nvim-nio as a dependency

### DIFF
--- a/lua/theprimeagen/lazy/neotest.lua
+++ b/lua/theprimeagen/lazy/neotest.lua
@@ -2,6 +2,7 @@ return {
     {
         "nvim-neotest/neotest",
         dependencies = {
+            "nvim-neotest/nvim-nio",
             "nvim-lua/plenary.nvim",
             "antoinemadec/FixCursorHold.nvim",
             "nvim-treesitter/nvim-treesitter",


### PR DESCRIPTION
Based on [Neo Test installation guide](https://github.com/nvim-neotest/nvim-nio?tab=readme-ov-file#installation) is required as a dependency. So to prevent errors in any fresh install I had to add this.