### PR TITLE
Change LSP restart command to support nvim v0.12

### DIFF
--- a/lua/theprimeagen/remap.lua
+++ b/lua/theprimeagen/remap.lua
@@ -12,7 +12,7 @@ vim.keymap.set("n", "<C-u>", "<C-u>zz")
 vim.keymap.set("n", "n", "nzzzv")
 vim.keymap.set("n", "N", "Nzzzv")
 vim.keymap.set("n", "=ap", "ma=ap'a")
-vim.keymap.set("n", "<leader>zig", "<cmd>LspRestart<cr>")
+vim.keymap.set("n", "<leader>zig", "<cmd>lsp restart<cr>")
 
 vim.keymap.set("n", "<leader>vwm", function()
     require("vim-with-me").StartVimWithMe()


### PR DESCRIPTION
Based on [commands section of nvim-lspconfig repo on GitHub](https://github.com/neovim/nvim-lspconfig#commands) this command is changed from `:LspRestart` to `:lsp restart`.